### PR TITLE
Rename read_exact to read_exact_ to avoid confict in nightly

### DIFF
--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -81,7 +81,7 @@ struct DibV5 {
 /// Reads a BMP header.
 fn read_header<R: Read+Seek>(reader: &mut R) -> io::Result<BmpHeader> {
     let mut bmp_header = [0u8; 18]; // bmp header + size of dib header
-    try!(reader.read_exact(&mut bmp_header[..]));
+    try!(reader.read_exact_(&mut bmp_header[..]));
 
     if &bmp_header[0..2] != [0x42, 0x4d] {
         return error("corrupt bmp header");
@@ -99,7 +99,7 @@ fn read_header<R: Read+Seek>(reader: &mut R) -> io::Result<BmpHeader> {
         _ => return error("unsupported dib version"),
     };
     let mut dib_header = vec![0u8; dib_size-4];
-    try!(reader.read_exact(&mut dib_header[..]));
+    try!(reader.read_exact_(&mut dib_header[..]));
 
     Ok(BmpHeader {
         file_size             : u32_from_le(&bmp_header[2..6]),
@@ -168,7 +168,7 @@ fn read_header<R: Read+Seek>(reader: &mut R) -> io::Result<BmpHeader> {
 pub fn detect<R: Read+Seek>(reader: &mut R) -> bool {
     let mut bmp_header = [0u8; 18]; // bmp header + size of dib header
     let result =
-        reader.read_exact(&mut bmp_header[..]).is_ok()
+        reader.read_exact_(&mut bmp_header[..]).is_ok()
         && &bmp_header[0..2] == [0x42, 0x4d]
         && match u32_from_le(&bmp_header[14..18]) {
             12 | 40 | 52 | 56 | 108 | 124 => true,
@@ -249,7 +249,7 @@ pub fn read<R: Read+Seek>(reader: &mut R, req_fmt: ColFmt) -> io::Result<Image> 
     let (palette, mut depaletted_line) =
         if paletted {
             let mut palette = vec![0u8; palette_length * pe_fmt.bytes_pp()];
-            try!(reader.read_exact(&mut palette[..]));
+            try!(reader.read_exact_(&mut palette[..]));
             (palette, vec![0u8; hdr.width as usize * pe_fmt.bytes_pp()])
         } else {
             (Vec::new(), Vec::new())
@@ -286,7 +286,7 @@ pub fn read<R: Read+Seek>(reader: &mut R, req_fmt: ColFmt) -> io::Result<Image> 
         vec![0u8; hdr.width as usize * hdr.height.abs() as usize * tgt_bytespp];
 
     for _ in (0 .. hdr.height.abs()) {
-        try!(reader.read_exact(&mut src_line_buf[..]));
+        try!(reader.read_exact_(&mut src_line_buf[..]));
         let src_line = &src_line_buf[..src_linesize];
 
         if paletted {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,7 +505,7 @@ fn bgra_to_rgba(src_line: &[u8], tgt_line: &mut[u8]) {
 
 trait IFRead {
     fn read_u8(&mut self) -> io::Result<u8>;
-    fn read_exact(&mut self, buf: &mut[u8]) -> io::Result<()>;
+    fn read_exact_(&mut self, buf: &mut[u8]) -> io::Result<()>;
 }
 
 impl<R: Read> IFRead for R {
@@ -518,7 +518,7 @@ impl<R: Read> IFRead for R {
         }
     }
 
-    fn read_exact(&mut self, buf: &mut[u8]) -> io::Result<()> {
+    fn read_exact_(&mut self, buf: &mut[u8]) -> io::Result<()> {
         let mut ready = 0;
         while ready < buf.len() {
             let got = try!(self.read(&mut buf[ready..]));

--- a/src/tga.rs
+++ b/src/tga.rs
@@ -50,7 +50,7 @@ pub fn read_info<R: Read>(reader: &mut R) -> io::Result<Info> {
 /// The fields are not parsed into enums or anything like that.
 fn read_header<R: Read>(reader: &mut R) -> io::Result<TgaHeader> {
     let mut buf = [0u8; 18];
-    try!(reader.read_exact(&mut buf));
+    try!(reader.read_exact_(&mut buf));
 
     let hdr = TgaHeader {
         id_length      : buf[0],
@@ -195,7 +195,7 @@ fn decode<R: Read>(dc: &mut TgaDecoder<R>) -> io::Result<Vec<u8>> {
 
     if !dc.rle {
         for _j in (0 .. dc.h) {
-            try!(dc.stream.read_exact(&mut src_line[0..src_linesize]));
+            try!(dc.stream.read_exact_(&mut src_line[0..src_linesize]));
             convert(&src_line[..], &mut result[ti as usize..(ti+tgt_linesize) as usize]);
             ti += tgt_stride;
         }
@@ -221,14 +221,14 @@ fn decode<R: Read>(dc: &mut TgaDecoder<R>) -> io::Result<Vec<u8>> {
             let gotten: usize = src_linesize - wanted;
             let copysize: usize = min(plen, wanted);
             if its_rle {
-                try!(dc.stream.read_exact(&mut rbuf[0..bytes_pp]));
+                try!(dc.stream.read_exact_(&mut rbuf[0..bytes_pp]));
                 let mut p = gotten;
                 while p < gotten+copysize {
                     copy_memory(&rbuf[0..bytes_pp], &mut src_line[p..p+bytes_pp]);
                     p += bytes_pp;
                 }
             } else {    // it's raw
-                try!(dc.stream.read_exact(&mut src_line[gotten..gotten+copysize]));
+                try!(dc.stream.read_exact_(&mut src_line[gotten..gotten+copysize]));
             }
             wanted -= copysize;
             plen -= copysize;


### PR DESCRIPTION
`read_exact` has recently been added to `io::Read` in nightly. This causes an ambiguous call error with the local `IFRead` trait. This PR just changes the name of the function slightly to avoid the conflict in the meantime. A UFCS call would also work, but it's easy to forget to do it, which would result in nightly breaking silently again; just changing the name for now is more robust I think.